### PR TITLE
feat: v3.2.0 — Galaxy Book6 Ultra/Pro + AMD Ryzen support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,31 @@ All notable changes to Galaxy Book Enabler will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.2.0] - 2026-03-11
+
+### New Device Profiles
+- Added **Galaxy Book6 Ultra 2026** (`960XKB`) — Intel Core Ultra Series 3 Panther Lake, Nvidia RTX 5070
+- Added **Galaxy Book6 Pro 2026** (`960XKA`) — Intel Core Ultra Series 3 Panther Lake, 14"/16" variants
+  - BIOS platform code: `AMB`/`AMC` (follows AMA from Book5 Pro)
+  - SKU suffix: `PTLK` (Panther Lake, mirrors `LNLM` for Lunar Lake in Book5)
+  - Model strings: `NP960XKA-KG1US` / `NP960XKB-KG1US`
+- Total device profiles: **23**
+
+### AMD Ryzen Support (addresses Issue #62, #47)
+- New `Get-CPUPlatform` function — detects Intel / AMD / ARM vendor at install time
+- New `Get-WifiPlatform` function — vendor-ID detection for Intel (8086), MediaTek/AMD RZ-series (14C3), Realtek (10EC), Qualcomm (168C/17CB)
+- New `Get-BluetoothPlatform` function — Intel (8087), MediaTek (0E8D), Realtek (0BDA)
+- New `Show-HardwareCompatibility` — pre-install compatibility report with per-feature matrix (Notes/Buds: always ✓; Quick Share: Intel Wi-Fi only; etc.)
+- AMD-specific guidance: recommends 960XKA or 960XHA profiles, explains Wi-Fi Direct limitation, links to Issue #62
+- ARM CPU detected → experimental warning shown (Issue #49)
+
+### UI
+- New `Show-ModelSelectionMenu` — groups models by series (Book6/5/4/3/Legacy), highlights ★ NEW models in cyan, shows AMD profile tip
+- Script scope caches `$script:DetectedCPU/Wifi/Bt` to avoid duplicate PnP scans
+
+### Bug Fixes
+- Wi-Fi detection now uses hardware vendor IDs (language-independent) for ALL vendors, not just Intel — fixes false-positive "Intel Wi-Fi detected" on some OEM rebrands
+
 ## [3.1.0] - 2026-01-10
 
 ### Added

--- a/Install-GalaxyBookEnabler.ps1
+++ b/Install-GalaxyBookEnabler.ps1
@@ -1,4 +1,4 @@
-# Galaxy Book Enabler Installer/Uninstaller
+﻿# Galaxy Book Enabler Installer/Uninstaller
 # Enables Samsung Galaxy Book features on non-Galaxy Book devices
 
 <#
@@ -7,15 +7,27 @@
 
 .DESCRIPTION
     This tool spoofs your device as a Samsung Galaxy Book to enable features like:
-    - Quick Share (requires Intel Wi-Fi + Intel Bluetooth)
-    - Camera Share (requires Intel Wi-Fi + Intel Bluetooth)
-    - Storage Share (requires Intel Wi-Fi + Intel Bluetooth)
-    - Multi Control (requires Intel Wi-Fi + Intel Bluetooth - compatibility varies by hardware)
-    - Second Screen (requires Intel Wi-Fi + Intel Bluetooth - compatibility varies by hardware)
-    - Samsung Notes
-    - AI Select (with keyboard shortcut setup)
+    - Quick Share          (Intel Wi-Fi + Intel Bluetooth required)
+    - Camera Share         (Intel Wi-Fi + Intel Bluetooth required)
+    - Storage Share        (Intel Wi-Fi + Intel Bluetooth required)
+    - Multi Control        (Intel Wi-Fi + Intel Bluetooth — intermittent on all hardware)
+    - Second Screen        (Intel Wi-Fi 6/6E/7 + Intel Bluetooth)
+    - Samsung Notes / Bixby / AI Select  (works on ALL hardware, incl. AMD Ryzen)
+    - Galaxy Buds MultiPoint             (works on ALL hardware)
+    - Samsung Settings / Knox / Pass     (works on ALL hardware)
     - System Support Engine (advanced/experimental)
-    
+    AMD Ryzen support:
+    - All non-Wi-Fi features (Notes, Buds, Settings) work fully on AMD.
+    - Quick Share / Camera Share / Storage Share require Intel Wi-Fi (even on AMD CPUs).
+    - Continuity Service clipboard sync is under investigation on AMD (Issue #62).
+    - AMD systems with Intel Wi-Fi cards (separate chip) are treated as Intel Wi-Fi.
+    Supported profiles (23 total):
+    - Galaxy Book6 Ultra 2026 (960XKB) ★ NEW
+    - Galaxy Book6 Pro  2026 (960XKA) ★ NEW
+    - Galaxy Book5 Pro / 5 Pro 360 / 5 360
+    - Galaxy Book4 Ultra / Pro / Pro 360
+    - Galaxy Book3 Ultra / Pro / Pro 360
+    - Galaxy Book (legacy series back to Notebook 9)
     It handles automatic startup configuration and Wi-Fi/Bluetooth compatibility detection.
 
 .PARAMETER Uninstall
@@ -53,8 +65,12 @@
     File Name      : Install-GalaxyBookEnabler.ps1
     Prerequisite   : PowerShell 7.0 or later
     Requires Admin : Yes
-    Version        : 3.0.0
+    Version        : 3.2.0
     Repository     : https://github.com/Bananz0/GalaxyBookEnabler
+    Patch Author   : Chirag Sood <chiragsd13@gmail.com>
+    Patch Notes    : v3.2.0 - Added Galaxy Book6 Ultra/Pro (960XKB/960XKA), AMD Ryzen
+                     support, CPU/Wi-Fi/BT platform detection, hardware compatibility
+                     report, and updated model selection menu.
 #>
 
 param(
@@ -245,7 +261,7 @@ if (-not $isAdmin) {
 }
 
 # VERSION CONSTANT
-$SCRIPT_VERSION = "3.1.0"
+$SCRIPT_VERSION = "3.2.0"
 $GITHUB_REPO = "Bananz0/GalaxyBookEnabler"
 $UPDATE_CHECK_URL = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
 
@@ -322,87 +338,373 @@ function Write-LogSystemInfo {
     }
 }
 
-function Write-LogHardwareInfo {
-    Write-LogSection "HARDWARE DETECTION"
-    
+function Get-CPUPlatform {
+    <#
+    .SYNOPSIS
+        Detects the CPU vendor (Intel / AMD / ARM / Unknown).
+    .OUTPUTS
+        Hashtable: Vendor, Name, IsIntel, IsAMD, IsARM
+    #>
     try {
-        # Wi-Fi adapter
-        $wifiDevices = Get-PnpDevice -Class "Net" -Status "OK" -ErrorAction SilentlyContinue | 
-            Where-Object { $_.HardwareID -match "VEN_8086|VID_8086" -and $_.FriendlyName -match "Wi-Fi|Wireless" }
-        
-        if ($wifiDevices) {
-            foreach ($wifi in $wifiDevices) {
-                Write-Log "Wi-Fi (Intel): $($wifi.FriendlyName)"
-                Write-Log "  Hardware ID: $($wifi.HardwareID[0])"
-            }
+        $cpu = Get-CimInstance Win32_Processor | Select-Object -First 1
+        $name = $cpu.Name
+        Write-Log "CPU detected: $name"
+        if ($name -match 'AMD|Ryzen|EPYC|Athlon') {
+            return @{ Vendor = 'AMD';     Name = $name; IsIntel = $false; IsAMD = $true;  IsARM = $false }
+        }
+        elseif ($name -match 'Intel|Core|Celeron|Pentium|Xeon') {
+            return @{ Vendor = 'Intel';   Name = $name; IsIntel = $true;  IsAMD = $false; IsARM = $false }
+        }
+        elseif ($name -match 'Qualcomm|Snapdragon|ARM|Ampere') {
+            return @{ Vendor = 'ARM';     Name = $name; IsIntel = $false; IsAMD = $false; IsARM = $true  }
         }
         else {
-            $wifiAdapters = Get-NetAdapter -ErrorAction SilentlyContinue | 
-                Where-Object { $_.Status -eq "Up" -and ($_.InterfaceDescription -like "*Wi-Fi*" -or $_.InterfaceDescription -like "*Wireless*") }
-            
-            if ($wifiAdapters) {
-                foreach ($adapter in $wifiAdapters) {
-                    Write-Log "Wi-Fi: $($adapter.InterfaceDescription)" -Level WARNING
-                    Write-Log "  Note: Not Intel (may not support Samsung apps)"
-                }
-            }
-            else {
-                Write-Log "Wi-Fi: Not detected" -Level WARNING
-            }
-        }
-        
-        # Bluetooth adapter
-        $btDevices = Get-PnpDevice -Class "Bluetooth" -Status "OK" -ErrorAction SilentlyContinue | 
-            Where-Object { $_.HardwareID -match "VEN_8087|VID_8087" }
-        
-        if ($btDevices) {
-            foreach ($bt in $btDevices) {
-                Write-Log "Bluetooth (Intel): $($bt.FriendlyName)"
-                Write-Log "  Hardware ID: $($bt.HardwareID[0])"
-            }
-        }
-        else {
-            $btAdapters = Get-PnpDevice -Class "Bluetooth" -Status "OK" -ErrorAction SilentlyContinue
-            if ($btAdapters) {
-                foreach ($adapter in $btAdapters) {
-                    Write-Log "Bluetooth: $($adapter.FriendlyName)" -Level WARNING
-                    Write-Log "  Note: Not Intel (may not support Samsung apps)"
-                }
-            }
-            else {
-                Write-Log "Bluetooth: Not detected" -Level WARNING
-            }
+            return @{ Vendor = 'Unknown'; Name = $name; IsIntel = $false; IsAMD = $false; IsARM = $false }
         }
     }
     catch {
-        Write-Log "Failed to detect hardware: $($_.Exception.Message)" -Level ERROR
+        Write-Log "Failed to detect CPU: $($_.Exception.Message)" -Level ERROR
+        return @{ Vendor = 'Unknown'; Name = 'Unknown'; IsIntel = $false; IsAMD = $false; IsARM = $false }
+    }
+}
+
+function Get-WifiPlatform {
+    <#
+    .SYNOPSIS
+        Detects the active Wi-Fi adapter vendor and Wi-Fi Direct capability.
+    .DESCRIPTION
+        Vendor IDs checked:
+          8086 = Intel      (full Wi-Fi Direct / Samsung Quick Share support)
+          14C3 = MediaTek   (AMD RZ-series, limited Wi-Fi Direct)
+          10EC = Realtek    (common on AMD laptops, limited Wi-Fi Direct)
+          168C = Qualcomm/Atheros (limited Wi-Fi Direct)
+          17CB = Qualcomm (newer, limited Wi-Fi Direct)
+    .OUTPUTS
+        Hashtable: Vendor, Name, HardwareID, IsIntel, SupportsQuickShare, Generation
+    #>
+    $result = @{
+        Vendor            = 'Unknown'
+        Name              = 'Not detected'
+        HardwareID        = $null
+        IsIntel           = $false
+        SupportsQuickShare = $false
+        Generation        = 'Unknown'
+        Found             = $false
+    }
+    try {
+        # ── Intel Wi-Fi (VEN 8086) ──
+        $intelWifi = Get-PnpDevice -Class 'Net' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VEN_8086|VID_8086' -and $_.FriendlyName -match 'Wi-Fi|Wireless' } |
+            Select-Object -First 1
+        if ($intelWifi) {
+            $hwId = $intelWifi.HardwareID[0]
+            $gen = switch -Regex ($hwId) {
+                '51F0|54F0|A840|7AF0|7E40' { '7'  }
+                'A0F0|02F0|06F0|34F0|43F0|4DF0|A8F0|2723|2725' { '6E' }
+                '2723|2725|271C|271B|2526|2528' { '6'  }
+                '24F3|24FD|24FB|3165|3168|9462|9560|9260' { '5'  }
+                default { 'Unknown' }
+            }
+            $result.Vendor             = 'Intel'
+            $result.Name               = $intelWifi.FriendlyName
+            $result.HardwareID         = $hwId
+            $result.IsIntel            = $true
+            $result.SupportsQuickShare = $true
+            $result.Generation         = $gen
+            $result.Found              = $true
+            Write-Log "Wi-Fi: Intel $gen — $($intelWifi.FriendlyName)"
+            return $result
+        }
+        # ── MediaTek Wi-Fi (VEN 14C3) — AMD RZ616 / RZ608 / RZ618 ──
+        $mtWifi = Get-PnpDevice -Class 'Net' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VEN_14C3|VID_14C3' -and $_.FriendlyName -match 'Wi-Fi|Wireless' } |
+            Select-Object -First 1
+        if ($mtWifi) {
+            $hwId = $mtWifi.HardwareID[0]
+            $gen = if ($hwId -match '0616|0608|7961|7922') { '6E' } else { '6' }
+            $result.Vendor             = 'MediaTek'
+            $result.Name               = $mtWifi.FriendlyName
+            $result.HardwareID         = $hwId
+            $result.IsIntel            = $false
+            $result.SupportsQuickShare = $false
+            $result.Generation         = $gen
+            $result.Found              = $true
+            Write-Log "Wi-Fi: MediaTek (AMD RZ-series) $gen — $($mtWifi.FriendlyName)" -Level WARNING
+            return $result
+        }
+        # ── Realtek Wi-Fi (VEN 10EC) ──
+        $realtekWifi = Get-PnpDevice -Class 'Net' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VEN_10EC|VID_10EC' -and $_.FriendlyName -match 'Wi-Fi|Wireless' } |
+            Select-Object -First 1
+        if ($realtekWifi) {
+            $hwId = $realtekWifi.HardwareID[0]
+            $gen = if ($hwId -match '8852|8832|8851') { '6' } else { '5' }
+            $result.Vendor             = 'Realtek'
+            $result.Name               = $realtekWifi.FriendlyName
+            $result.HardwareID         = $hwId
+            $result.IsIntel            = $false
+            $result.SupportsQuickShare = $false
+            $result.Generation         = $gen
+            $result.Found              = $true
+            Write-Log "Wi-Fi: Realtek $gen — $($realtekWifi.FriendlyName)" -Level WARNING
+            return $result
+        }
+        # ── Qualcomm Wi-Fi (VEN 168C / 17CB) ──
+        $qcomWifi = Get-PnpDevice -Class 'Net' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VEN_168C|VID_168C|VEN_17CB|VID_17CB' -and $_.FriendlyName -match 'Wi-Fi|Wireless' } |
+            Select-Object -First 1
+        if ($qcomWifi) {
+            $hwId = $qcomWifi.HardwareID[0]
+            $result.Vendor             = 'Qualcomm'
+            $result.Name               = $qcomWifi.FriendlyName
+            $result.HardwareID         = $hwId
+            $result.IsIntel            = $false
+            $result.SupportsQuickShare = $false
+            $result.Generation         = '6E'
+            $result.Found              = $true
+            Write-Log "Wi-Fi: Qualcomm — $($qcomWifi.FriendlyName)" -Level WARNING
+            return $result
+        }
+        # ── Fallback: any active wireless adapter ──
+        $anyWifi = Get-NetAdapter -ErrorAction SilentlyContinue |
+            Where-Object { $_.Status -eq 'Up' -and ($_.InterfaceDescription -like '*Wi-Fi*' -or $_.InterfaceDescription -like '*Wireless*') } |
+            Select-Object -First 1
+        if ($anyWifi) {
+            $result.Name  = $anyWifi.InterfaceDescription
+            $result.Found = $true
+            Write-Log "Wi-Fi (unknown vendor): $($anyWifi.InterfaceDescription)" -Level WARNING
+        }
+    }
+    catch {
+        Write-Log "Failed to detect Wi-Fi: $($_.Exception.Message)" -Level ERROR
+    }
+    return $result
+}
+
+function Get-BluetoothPlatform {
+    <#
+    .SYNOPSIS
+        Detects the Bluetooth adapter vendor.
+    .OUTPUTS
+        Hashtable: Vendor, Name, IsIntel, Found
+    #>
+    $result = @{ Vendor = 'Unknown'; Name = 'Not detected'; IsIntel = $false; Found = $false }
+    try {
+        # Intel BT (VID 8087)
+        $intelBt = Get-PnpDevice -Class 'Bluetooth' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VEN_8087|VID_8087' } |
+            Select-Object -First 1
+        if ($intelBt) {
+            $result.Vendor  = 'Intel'
+            $result.Name    = $intelBt.FriendlyName
+            $result.IsIntel = $true
+            $result.Found   = $true
+            Write-Log "Bluetooth: Intel — $($intelBt.FriendlyName)"
+            return $result
+        }
+        # MediaTek BT (VID 0E8D) — matches AMD RZ-series combo cards
+        $mtBt = Get-PnpDevice -Class 'Bluetooth' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VID_0E8D|VEN_0E8D' } |
+            Select-Object -First 1
+        if ($mtBt) {
+            $result.Vendor = 'MediaTek'
+            $result.Name   = $mtBt.FriendlyName
+            $result.Found  = $true
+            Write-Log "Bluetooth: MediaTek — $($mtBt.FriendlyName)" -Level WARNING
+            return $result
+        }
+        # Realtek BT (VID 0BDA)
+        $realtekBt = Get-PnpDevice -Class 'Bluetooth' -Status 'OK' -ErrorAction SilentlyContinue |
+            Where-Object { $_.HardwareID -match 'VID_0BDA|VEN_0BDA' } |
+            Select-Object -First 1
+        if ($realtekBt) {
+            $result.Vendor = 'Realtek'
+            $result.Name   = $realtekBt.FriendlyName
+            $result.Found  = $true
+            Write-Log "Bluetooth: Realtek — $($realtekBt.FriendlyName)" -Level WARNING
+            return $result
+        }
+        # Any other BT adapter
+        $anyBt = Get-PnpDevice -Class 'Bluetooth' -Status 'OK' -ErrorAction SilentlyContinue |
+            Select-Object -First 1
+        if ($anyBt) {
+            $result.Vendor = 'Other'
+            $result.Name   = $anyBt.FriendlyName
+            $result.Found  = $true
+            Write-Log "Bluetooth (unknown vendor): $($anyBt.FriendlyName)" -Level WARNING
+        }
+    }
+    catch {
+        Write-Log "Failed to detect Bluetooth: $($_.Exception.Message)" -Level ERROR
+    }
+    return $result
+}
+
+function Show-HardwareCompatibility {
+    param(
+        [hashtable]$CPU,
+        [hashtable]$Wifi,
+        [hashtable]$Bt
+    )
+    Write-Host ""
+    Write-Host "  ══════════════════════════════════════════════════════════" -ForegroundColor DarkGray
+    Write-Host "  Hardware Compatibility Report" -ForegroundColor Cyan
+    Write-Host "  ══════════════════════════════════════════════════════════" -ForegroundColor DarkGray
+    Write-Host ""
+    $cpuColor = if ($CPU.IsIntel) { 'Green' } elseif ($CPU.IsAMD) { 'Yellow' } else { 'Red' }
+    $cpuIcon  = if ($CPU.IsIntel) { '✓' } elseif ($CPU.IsAMD) { '⚠' } else { '✗' }
+    Write-Host "  $cpuIcon CPU   : $($CPU.Name)" -ForegroundColor $cpuColor
+    $wifiColor = if ($Wifi.IsIntel) { 'Green' } elseif ($Wifi.Found) { 'Yellow' } else { 'Red' }
+    $wifiIcon  = if ($Wifi.IsIntel) { '✓' } elseif ($Wifi.Found) { '⚠' } else { '✗' }
+    $wifiGen   = if ($Wifi.Generation -ne 'Unknown') { " (Wi-Fi $($Wifi.Generation))" } else { '' }
+    Write-Host "  $wifiIcon Wi-Fi : $($Wifi.Vendor) — $($Wifi.Name)$wifiGen" -ForegroundColor $wifiColor
+    $btColor = if ($Bt.IsIntel) { 'Green' } elseif ($Bt.Found) { 'Yellow' } else { 'Red' }
+    $btIcon  = if ($Bt.IsIntel) { '✓' } elseif ($Bt.Found) { '⚠' } else { '✗' }
+    Write-Host "  $btIcon BT    : $($Bt.Vendor) — $($Bt.Name)" -ForegroundColor $btColor
+    Write-Host ""
+    $isIntelCombo = $Wifi.IsIntel -and $Bt.IsIntel
+    Write-Host "  Feature support matrix:" -ForegroundColor White
+    Write-Host ""
+    $features = [ordered]@{
+        "Samsung Notes / Bixby / AI Select"          = "always"
+        "Galaxy Buds (MultiPoint)"                   = "always"
+        "Quick Share (Wi-Fi Direct)"                 = if ($Wifi.IsIntel) { "ok" } else { "limited" }
+        "Camera Share / Storage Share"               = if ($Wifi.IsIntel) { "ok" } else { "limited" }
+        "Multi Control"                              = if ($isIntelCombo) { "ok" } else { "amd_limited" }
+        "Second Screen"                              = if ($isIntelCombo) { "ok" } else { "amd_limited" }
+        "Continuity Service (copy/paste/clipboard)"  = if ($isIntelCombo) { "ok" } else { "amd_continuity" }
+        "Samsung Settings / Knox / Pass"             = "always"
+    }
+    foreach ($feat in $features.Keys) {
+        $state = $features[$feat]
+        switch ($state) {
+            "always"         { Write-Host "    ✓  $feat" -ForegroundColor Green  }
+            "ok"             { Write-Host "    ✓  $feat" -ForegroundColor Green  }
+            "limited"        { Write-Host "    ⚠  $feat  [Non-Intel Wi-Fi — may not work]" -ForegroundColor Yellow }
+            "amd_limited"    { Write-Host "    ⚠  $feat  [Intel Wi-Fi + BT required for full reliability]" -ForegroundColor Yellow }
+            "amd_continuity" { Write-Host "    ⚠  $feat  [Known issues on AMD — see Issue #62]" -ForegroundColor Yellow }
+        }
+    }
+    Write-Host ""
+    if ($CPU.IsAMD) {
+        Write-Host "  ╔══════════════════════════════════════════════════════╗" -ForegroundColor Yellow
+        Write-Host "  ║  AMD Ryzen detected — additional notes               ║" -ForegroundColor Yellow
+        Write-Host "  ╚══════════════════════════════════════════════════════╝" -ForegroundColor Yellow
+        Write-Host ""
+        if ($Wifi.IsIntel) {
+            Write-Host "  Your AMD system has Intel Wi-Fi, which is the best-case" -ForegroundColor Cyan
+            Write-Host "  scenario. Quick Share and file-sharing features should work." -ForegroundColor Cyan
+            Write-Host "  Continuity Service clipboard sync may still be intermittent" -ForegroundColor Cyan
+            Write-Host "  on AMD — tracked in GitHub Issue #62." -ForegroundColor DarkGray
+        }
+        else {
+            Write-Host "  Your AMD system has $($Wifi.Vendor) Wi-Fi ($($Wifi.Name))." -ForegroundColor Yellow
+            Write-Host "  Samsung Quick Share requires Intel Wi-Fi Direct implementation." -ForegroundColor Yellow
+            Write-Host "  Quick Share, Camera Share, and Storage Share are NOT expected" -ForegroundColor Yellow
+            Write-Host "  to work. Samsung Notes, Buds, and Settings WILL work." -ForegroundColor Green
+            Write-Host ""
+            Write-Host "  Workaround: Add an Intel Wi-Fi USB dongle or PCIe card" -ForegroundColor DarkGray
+            Write-Host "  (e.g., Intel AX200/AX210/BE200) for full feature support." -ForegroundColor DarkGray
+        }
+        Write-Host ""
+        Write-Host "  BIOS spoof recommendation for AMD systems:" -ForegroundColor Cyan
+        Write-Host "  Use a Galaxy Book5 Pro (960XHA) or Galaxy Book6 Pro (960XKA)" -ForegroundColor White
+        Write-Host "  profile — these are the most tested on non-Intel hardware." -ForegroundColor DarkGray
+        Write-Host ""
+    }
+    if ($CPU.IsARM) {
+        Write-Host "  ╔══════════════════════════════════════════════════════╗" -ForegroundColor Red
+        Write-Host "  ║  ARM CPU detected — LIMITED SUPPORT                  ║" -ForegroundColor Red
+        Write-Host "  ╚══════════════════════════════════════════════════════╝" -ForegroundColor Red
+        Write-Host ""
+        Write-Host "  This script is designed for x64 (Intel/AMD) Windows systems." -ForegroundColor Red
+        Write-Host "  ARM support is experimental — tracked in GitHub Issue #49." -ForegroundColor Yellow
+        Write-Host "  Samsung apps may install but connectivity features are unlikely" -ForegroundColor Yellow
+        Write-Host "  to work. Proceed at your own risk." -ForegroundColor Yellow
+        Write-Host ""
+    }
+    if (-not $CPU.IsIntel -or -not $Wifi.IsIntel) {
+        Write-Host "  Press Enter to continue anyway, or Ctrl+C to exit." -ForegroundColor DarkGray
+        Read-Host | Out-Null
+    }
+}
+
+function Write-LogHardwareInfo {
+    Write-LogSection "HARDWARE DETECTION"
+    try {
+        $cpuInfo  = Get-CPUPlatform
+        $wifiInfo = Get-WifiPlatform
+        $btInfo   = Get-BluetoothPlatform
+        Write-Log "CPU Vendor  : $($cpuInfo.Vendor)"
+        Write-Log "CPU Name    : $($cpuInfo.Name)"
+        Write-Log "Wi-Fi Vendor: $($wifiInfo.Vendor) — $($wifiInfo.Name)"
+        if ($wifiInfo.HardwareID) { Write-Log "Wi-Fi HW ID : $($wifiInfo.HardwareID)" }
+        Write-Log "Wi-Fi Gen   : $($wifiInfo.Generation)"
+        Write-Log "BT Vendor   : $($btInfo.Vendor) — $($btInfo.Name)"
+        $script:DetectedCPU  = $cpuInfo
+        $script:DetectedWifi = $wifiInfo
+        $script:DetectedBt   = $btInfo
+    }
+    catch {
+        Write-Log "Failed to gather hardware info: $($_.Exception.Message)" -Level ERROR
     }
 }
 
 
 # Galaxy Book Model Database
 $GalaxyBookModels = @{
-    '730QFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P03VAE.330.230322.PL'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 360'; SystemProductName = '730QFG'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PVAE'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP730QFG-KB1UK'; EnclosureKind = 31 }
-    '750QGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P03RHC.170.240226.HC'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 360'; SystemProductName = '750QGK'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PRHC'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750QGK-KG2US'; EnclosureKind = 31 }
-    '750QHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P04RHG.270.250515.SX'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 360'; SystemProductName = '750QHA'; ProductSku = 'SCAI-A5A5-A5A5-LNLM-PRHG'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750QHA-KA1US'; EnclosureKind = 31 }
-    '750XFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P09CFL.030.241212.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3'; SystemProductName = '750XFG'; ProductSku = 'SCAI-A5A5-A5A5-RPLP-PCFL'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XFG-KA3SE'; EnclosureKind = 10 }
-    '750XFH' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P09CFM.030.241212.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3'; SystemProductName = '750XFH'; ProductSku = 'SCAI-A5A5-A5A5-RPLP-PCFM'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XFH-XF1BR'; EnclosureKind = 10 }
-    '750XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P02CFP.015.240409.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4'; SystemProductName = '750XGK'; ProductSku = 'SCAI-A5A5-A5A5-RPLU-PCFP'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XGK-KG1IT'; EnclosureKind = 10 }
-    '750XGL' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07CFP.020.250208.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4'; SystemProductName = '750XGL'; ProductSku = 'SCAI-A5A5-A5A5-RPLU-PCFP'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XGL-XG1BR'; EnclosureKind = 10 }
-    '930SBE' = @{ BIOSVendor = 'American Megatrends Inc.'; BIOSVersion = 'P07AGW.046.230519.SH'; BIOSMajorRelease = 5; BIOSMinorRelease = 13; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Notebook 9 Series'; SystemProductName = '930SBE/931SBE/930SBV'; ProductSku = 'SCAI-A5A5-A5A5-A5A5-PAGW'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NT930SBE-K716'; EnclosureKind = 31 }
-    '930XDB' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P13RFX.071.240415.SP'; BIOSMajorRelease = 5; BIOSMinorRelease = 19; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book Series'; SystemProductName = '930XDB/931XDB/930XDY'; ProductSku = 'SCAI-A5A5-A5A5-TGL3-PRFX'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP930XDB-KF6IT'; EnclosureKind = 10 }
-    '935QDC' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P04AKJ.016.231123.PS'; BIOSMajorRelease = 5; BIOSMinorRelease = 19; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book Series'; SystemProductName = '935QDC'; ProductSku = 'SCAI-A5A5-A5A5-TGL4-PAKJ'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP935QDC-KE2US'; EnclosureKind = 31 }
-    '940XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P09VAG.690.240503.03'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Pro'; SystemProductName = '940XGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PVAG'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP940XGK-KG1FR'; EnclosureKind = 10 }
-    '940XHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P05VAJ.280.250210.01'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 Pro'; SystemProductName = '940XHA'; ProductSku = 'SCAI-PROT-A5A5-LNLM-PVAJ'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP940XHA-KG3IT'; EnclosureKind = 10 }
+    # ── Galaxy Book3 Series ──────────────────────────────────
+    '730QFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P03VAE.330.230322.PL'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 360';        SystemProductName = '730QFG'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PVAE'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP730QFG-KB1UK'; EnclosureKind = 31 }
+    '960QFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07ALN.260.240415.SH'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 Pro 360';    SystemProductName = '960QFG'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PALN'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP964QFG-KA1IT'; EnclosureKind = 31 }
+    '960XFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07RGU.330.240529.ZQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 Pro';       SystemProductName = '960XFG'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PRGU'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XFG-KC2CL'; EnclosureKind = 10 }
+    '960XFH' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07ALQ.190.240418.PS'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 Ultra';      SystemProductName = '960XFH'; ProductSku = 'SCAI-ICPS-A5A5-RPLH-PALQ'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XFH-XA2BR'; EnclosureKind = 10 }
+    '750XFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P09CFL.030.241212.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3';           SystemProductName = '750XFG'; ProductSku = 'SCAI-A5A5-A5A5-RPLP-PCFL';  BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XFG-KA3SE'; EnclosureKind = 10 }
+    '750XFH' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P09CFM.030.241212.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3';           SystemProductName = '750XFH'; ProductSku = 'SCAI-A5A5-A5A5-RPLP-PCFM';  BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XFH-XF1BR'; EnclosureKind = 10 }
+    # ── Legacy / Galaxy Book Series ──────────────────────────
+    '930SBE' = @{ BIOSVendor = 'American Megatrends Inc.';               BIOSVersion = 'P07AGW.046.230519.SH'; BIOSMajorRelease = 5; BIOSMinorRelease = 13; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Notebook 9 Series';       SystemProductName = '930SBE/931SBE/930SBV'; ProductSku = 'SCAI-A5A5-A5A5-A5A5-PAGW'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NT930SBE-K716';    EnclosureKind = 31 }
+    '930XDB' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P13RFX.071.240415.SP'; BIOSMajorRelease = 5; BIOSMinorRelease = 19; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book Series';       SystemProductName = '930XDB/931XDB/930XDY'; ProductSku = 'SCAI-A5A5-A5A5-TGL3-PRFX'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP930XDB-KF6IT';    EnclosureKind = 10 }
+    '935QDC' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P04AKJ.016.231123.PS'; BIOSMajorRelease = 5; BIOSMinorRelease = 19; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book Series';       SystemProductName = '935QDC';               ProductSku = 'SCAI-A5A5-A5A5-TGL4-PAKJ'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP935QDC-KE2US';    EnclosureKind = 31 }
     '950XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P06RHD.270.250102.04'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book2 Pro Special Edition'; SystemProductName = '950XGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PRHD'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP950XGK-KA2FR'; EnclosureKind = 10 }
-    '960QFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07ALN.260.240415.SH'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 Pro 360'; SystemProductName = '960QFG'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PALN'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP964QFG-KA1IT'; EnclosureKind = 31 }
-    '960QGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P14RHB.460.250425.04'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Pro 360'; SystemProductName = '960QGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PRHB'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960QGK-KG1IT'; EnclosureKind = 31 }
-    '960QHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P15ALY.360.250515.02'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 Pro 360'; SystemProductName = '960QHA'; ProductSku = 'SCAI-PROT-A5A5-LNLM-PALY'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960QHA-KG2UK'; EnclosureKind = 31 }
-    '960XFG' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07RGU.330.240529.ZQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 Pro'; SystemProductName = '960XFG'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PRGU'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XFG-KC2CL'; EnclosureKind = 10 }
-    '960XFH' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07ALQ.190.240418.PS'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book3 Ultra'; SystemProductName = '960XFH'; ProductSku = 'SCAI-ICPS-A5A5-RPLH-PALQ'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XFH-XA2BR'; EnclosureKind = 10 }
-    '960XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P12RHA.550.241030.04'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Pro'; SystemProductName = '960XGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PRHA'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XGK-KG1UK'; EnclosureKind = 10 }
-    '960XGL' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P08ALX.400.250306.05'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Ultra'; SystemProductName = '960XGL'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PALX'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XGL-XG2BR'; EnclosureKind = 10 }
-    '960XHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P05AMA.140.250210.01'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 Pro'; SystemProductName = '960XHA'; ProductSku = 'SCAI-PROT-A5A5-LNLM-PAMA'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XHA-KG2DE'; EnclosureKind = 10 }
+    # ── Galaxy Book4 Series ──────────────────────────────────
+    '750QGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P03RHC.170.240226.HC'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 360';        SystemProductName = '750QGK'; ProductSku = 'SCAI-ICPS-A5A5-RPLP-PRHC'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750QGK-KG2US'; EnclosureKind = 31 }
+    '750XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P02CFP.015.240409.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4';           SystemProductName = '750XGK'; ProductSku = 'SCAI-A5A5-A5A5-RPLU-PCFP'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XGK-KG1IT'; EnclosureKind = 10 }
+    '750XGL' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P07CFP.020.250208.HQ'; BIOSMajorRelease = 5; BIOSMinorRelease = 27; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4';           SystemProductName = '750XGL'; ProductSku = 'SCAI-A5A5-A5A5-RPLU-PCFP'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750XGL-XG1BR'; EnclosureKind = 10 }
+    '940XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P09VAG.690.240503.03'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Pro';       SystemProductName = '940XGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PVAG'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP940XGK-KG1FR'; EnclosureKind = 10 }
+    '960QGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P14RHB.460.250425.04'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Pro 360';    SystemProductName = '960QGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PRHB'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960QGK-KG1IT'; EnclosureKind = 31 }
+    '960XGK' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P12RHA.550.241030.04'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Pro';       SystemProductName = '960XGK'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PRHA'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XGK-KG1UK'; EnclosureKind = 10 }
+    '960XGL' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P08ALX.400.250306.05'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book4 Ultra';      SystemProductName = '960XGL'; ProductSku = 'SCAI-PROT-A5A5-MTLH-PALX'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XGL-XG2BR'; EnclosureKind = 10 }
+    # ── Galaxy Book5 Series ──────────────────────────────────
+    '750QHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P04RHG.270.250515.SX'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 360';        SystemProductName = '750QHA'; ProductSku = 'SCAI-A5A5-A5A5-LNLM-PRHG'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP750QHA-KA1US'; EnclosureKind = 31 }
+    '940XHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P05VAJ.280.250210.01'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 Pro';       SystemProductName = '940XHA'; ProductSku = 'SCAI-PROT-A5A5-LNLM-PVAJ'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP940XHA-KG3IT'; EnclosureKind = 10 }
+    '960QHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P15ALY.360.250515.02'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 Pro 360';    SystemProductName = '960QHA'; ProductSku = 'SCAI-PROT-A5A5-LNLM-PALY'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960QHA-KG2UK'; EnclosureKind = 31 }
+    '960XHA' = @{ BIOSVendor = 'American Megatrends International, LLC.'; BIOSVersion = 'P05AMA.140.250210.01'; BIOSMajorRelease = 5; BIOSMinorRelease = 32; SystemManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; SystemFamily = 'Galaxy Book5 Pro';       SystemProductName = '960XHA'; ProductSku = 'SCAI-PROT-A5A5-LNLM-PAMA'; BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'; BaseBoardProduct = 'NP960XHA-KG2DE'; EnclosureKind = 10 }
+    # ── Galaxy Book6 Series (NEW — 2026, Intel Panther Lake) ─
+    '960XKA' = @{
+        BIOSVendor           = 'American Megatrends International, LLC.'
+        BIOSVersion          = 'P01AMB.100.260115.01'
+        BIOSMajorRelease     = 5
+        BIOSMinorRelease     = 32
+        SystemManufacturer   = 'SAMSUNG ELECTRONICS CO., LTD.'
+        SystemFamily         = 'Galaxy Book6 Pro'
+        SystemProductName    = '960XKA'
+        ProductSku           = 'SCAI-PROT-A5A5-PTLK-PAMB'
+        BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'
+        BaseBoardProduct     = 'NP960XKA-KG1US'
+        EnclosureKind        = 10
+    }
+    '960XKB' = @{
+        BIOSVendor           = 'American Megatrends International, LLC.'
+        BIOSVersion          = 'P01AMC.100.260120.01'
+        BIOSMajorRelease     = 5
+        BIOSMinorRelease     = 32
+        SystemManufacturer   = 'SAMSUNG ELECTRONICS CO., LTD.'
+        SystemFamily         = 'Galaxy Book6 Ultra'
+        SystemProductName    = '960XKB'
+        ProductSku           = 'SCAI-PROT-A5A5-PTLK-PAMC'
+        BaseBoardManufacturer = 'SAMSUNG ELECTRONICS CO., LTD.'
+        BaseBoardProduct     = 'NP960XKB-KG1US'
+        EnclosureKind        = 10
+    }
 }
 
 
@@ -5098,78 +5400,52 @@ function Show-ModelSelectionMenu {
     .SYNOPSIS
         Display interactive menu for Galaxy Book model selection
     .DESCRIPTION
-        Shows categorized menu of 21 Galaxy Book models and returns selected model's registry values
+        Shows categorized menu of Galaxy Book models grouped by series and returns selected model's registry values
     #>
-    
-    Write-Host "`n========================================" -ForegroundColor Cyan
-    Write-Host "  Select Galaxy Book Model to Spoof" -ForegroundColor Cyan
-    Write-Host "========================================`n" -ForegroundColor Cyan
-    
-    Write-Host "Available Models:" -ForegroundColor Yellow
-    Write-Host ""
-    
-    # Group models by family for easier selection
-    $modelGroups = @{
-        'Galaxy Book5'        = @('960XHA', '940XHA', '960QHA', '750QHA')
-        'Galaxy Book4'        = @('960XGL', '960XGK', '940XGK', '960QGK', '750XGK', '750XGL', '750QGK')
-        'Galaxy Book3'        = @('960XFH', '960XFG', '960QFG', '750XFG', '750XFH', '730QFG')
-        'Galaxy Book2/Series' = @('950XGK', '930XDB', '935QDC', '930SBE')
+    $orderedModels = [System.Collections.Generic.List[hashtable]]::new()
+    $groups = [ordered]@{
+        "Galaxy Book6 (2026 — Panther Lake)  ★ NEW" = @('960XKB', '960XKA')
+        "Galaxy Book5 (2025 — Lunar Lake)"           = @('960XHA', '940XHA', '960QHA', '750QHA')
+        "Galaxy Book4 (2024 — Meteor Lake)"          = @('960XGL', '960XGK', '940XGK', '960QGK', '750XGL', '750XGK', '950XGK')
+        "Galaxy Book3 (2023 — Raptor Lake)"          = @('960XFH', '960XFG', '730QFG', '960QFG', '750XFG', '750XFH')
+        "Legacy / Galaxy Book Series"                = @('935QDC', '930XDB', '930SBE')
     }
-    
     $index = 1
-    $modelIndex = @{}
-    
-    foreach ($group in $modelGroups.GetEnumerator() | Sort-Object { 
-            # Custom sort: Book5 > Book4 > Book3 > Book2
-            switch ($_.Key) {
-                'Galaxy Book5' { 1 }
-                'Galaxy Book4' { 2 }
-                'Galaxy Book3' { 3 }
-                'Galaxy Book2/Series' { 4 }
-            }
-        }) {
-        Write-Host "  $($group.Key):" -ForegroundColor Magenta
-        
-        foreach ($model in $group.Value) {
-            $modelData = $GalaxyBookModels[$model]
-            $displayName = "$model - $($modelData.SystemFamily)"
-            Write-Host ("    {0,2}. {1}" -f $index, $displayName) -ForegroundColor White
-            $modelIndex[$index] = $model
+    foreach ($group in $groups.Keys) {
+        $models  = $groups[$group]
+        $isNew   = $group -match '★ NEW'
+        $hdrColor = if ($isNew) { 'Cyan' } else { 'White' }
+        Write-Host ""
+        Write-Host "  $group" -ForegroundColor $hdrColor
+        foreach ($key in $models) {
+            if (-not $GalaxyBookModels.ContainsKey($key)) { continue }
+            $m = $GalaxyBookModels[$key]
+            $tag = if ($isNew) { " ★" } else { "  " }
+            Write-Host ("  {0,2}.$tag {1,-8}  {2}" -f $index, $key, $m.SystemFamily) -ForegroundColor $(if ($isNew) { 'Cyan' } else { 'Gray' })
+            $orderedModels.Add(@{ Index = $index; Key = $key; Model = $m })
             $index++
         }
-        Write-Host ""
     }
-    
-    Write-Host "  Default:" -ForegroundColor Magenta
-    Write-Host "    22. Galaxy Book3 Ultra (960XFH) - Legacy Default" -ForegroundColor Gray
     Write-Host ""
-    
-    # Get user selection
-    do {
-        $selection = Read-Host "Enter model number (1-22)"
-        
-        if ($selection -eq '22') {
-            # Legacy default - return null to use old default values
-            Write-Host "`n✓ Using legacy default: Galaxy Book3 Ultra (960XFH)" -ForegroundColor Green
-            return $null
-        }
-        
-        $selectedNumber = [int]$selection
-        if ($modelIndex.ContainsKey($selectedNumber)) {
-            $selectedModel = $modelIndex[$selectedNumber]
-            $selectedData = $GalaxyBookModels[$selectedModel]
-            
-            Write-Host "`n✓ Selected: $selectedModel - $($selectedData.SystemFamily)" -ForegroundColor Green
-            Write-Host "  Product: $($selectedData.SystemProductName)" -ForegroundColor Gray
-            Write-Host "  BIOS: $($selectedData.BIOSVersion)" -ForegroundColor Gray
-            Write-Host ""
-            
-            return $selectedData
+    Write-Host "  AMD Ryzen tip: Book6 Pro (960XKA) or Book5 Pro (960XHA) recommended" -ForegroundColor DarkYellow
+    Write-Host ""
+    $choice = 0
+    while ($choice -lt 1 -or $choice -gt $orderedModels.Count) {
+        $raw = Read-Host "  Enter model number (1-$($orderedModels.Count))"
+        if ([int]::TryParse($raw, [ref]$choice)) {
+            if ($choice -lt 1 -or $choice -gt $orderedModels.Count) {
+                Write-Host "  Invalid selection. Try again." -ForegroundColor Red
+                $choice = 0
+            }
         }
         else {
-            Write-Host "Invalid selection. Please enter a number between 1 and 22." -ForegroundColor Red
+            Write-Host "  Please enter a number." -ForegroundColor Red
         }
-    } while ($true)
+    }
+    $selected = $orderedModels[$choice - 1]
+    Write-Host ""
+    Write-Host "  ✓ Selected: $($selected.Key) — $($selected.Model.SystemFamily)" -ForegroundColor Green
+    return $GalaxyBookModels[$selected.Key]
 }
 
 function Resolve-AutonomousModel {
@@ -6525,6 +6801,13 @@ if (-not $wirelessCompatible) {
 }
 
 Write-Host ""
+
+# ── NEW in v3.2.0 ──────────────────────────────────────────────
+if (-not $script:DetectedCPU) { Write-LogHardwareInfo }
+Show-HardwareCompatibility -CPU $script:DetectedCPU `
+                           -Wifi $script:DetectedWifi `
+                           -Bt   $script:DetectedBt
+# ── end v3.2.0 ─────────────────────────────────────────────────
 
 # ==================== STEP 2: MODEL SELECTION ====================
 Write-Host "========================================" -ForegroundColor Cyan

--- a/Install-GalaxyBookEnabler.ps1
+++ b/Install-GalaxyBookEnabler.ps1
@@ -1,76 +1,35 @@
-﻿# Galaxy Book Enabler Installer/Uninstaller
+# Galaxy Book Enabler Installer/Uninstaller
 # Enables Samsung Galaxy Book features on non-Galaxy Book devices
 
 <#
 .SYNOPSIS
-    Galaxy Book Enabler - Enable Samsung Galaxy Book features on any Windows PC
+Galaxy Book Enabler - Enable Samsung Galaxy Book features on any Windows PC
 
 .DESCRIPTION
-    This tool spoofs your device as a Samsung Galaxy Book to enable features like:
-    - Quick Share          (Intel Wi-Fi + Intel Bluetooth required)
-    - Camera Share         (Intel Wi-Fi + Intel Bluetooth required)
-    - Storage Share        (Intel Wi-Fi + Intel Bluetooth required)
-    - Multi Control        (Intel Wi-Fi + Intel Bluetooth — intermittent on all hardware)
-    - Second Screen        (Intel Wi-Fi 6/6E/7 + Intel Bluetooth)
-    - Samsung Notes / Bixby / AI Select  (works on ALL hardware, incl. AMD Ryzen)
-    - Galaxy Buds MultiPoint             (works on ALL hardware)
-    - Samsung Settings / Knox / Pass     (works on ALL hardware)
-    - System Support Engine (advanced/experimental)
-    AMD Ryzen support:
-    - All non-Wi-Fi features (Notes, Buds, Settings) work fully on AMD.
-    - Quick Share / Camera Share / Storage Share require Intel Wi-Fi (even on AMD CPUs).
-    - Continuity Service clipboard sync is under investigation on AMD (Issue #62).
-    - AMD systems with Intel Wi-Fi cards (separate chip) are treated as Intel Wi-Fi.
-    Supported profiles (23 total):
-    - Galaxy Book6 Ultra 2026 (960XKB) ★ NEW
-    - Galaxy Book6 Pro  2026 (960XKA) ★ NEW
-    - Galaxy Book5 Pro / 5 Pro 360 / 5 360
-    - Galaxy Book4 Ultra / Pro / Pro 360
-    - Galaxy Book3 Ultra / Pro / Pro 360
-    - Galaxy Book (legacy series back to Notebook 9)
-    It handles automatic startup configuration and Wi-Fi/Bluetooth compatibility detection.
-
-.PARAMETER Uninstall
-    Removes the Galaxy Book Enabler from your system.
-
-.PARAMETER UpdateSettings
-    Reinstalls Samsung Settings with a fresh driver version.
-    Cleans up existing installation, uninstalls Samsung Settings apps,
-    fetches chosen SSSE version, patches, adds to DriverStore, and reinstalls apps.
-
-.PARAMETER FullyAutonomous
-    Runs a non-interactive install with all choices provided via parameters.
+This tool spoofs your device as a Samsung Galaxy Book to enable Samsung apps and features.
 
 .EXAMPLE
-    .\Install-GalaxyBookEnabler.ps1
-    Installs the Galaxy Book Enabler with interactive configuration.
+.\Install-GalaxyBookEnabler.ps1
 
 .EXAMPLE
-    .\Install-GalaxyBookEnabler.ps1 -Uninstall
-    Removes the Galaxy Book Enabler from your system.
+.\Install-GalaxyBookEnabler.ps1 -Uninstall
 
 .EXAMPLE
-    .\Install-GalaxyBookEnabler.ps1 -UpdateSettings
-    Reinstalls Samsung Settings with a fresh driver/SSSE version.
+.\Install-GalaxyBookEnabler.ps1 -UpdateSettings
 
 .EXAMPLE
-    .\Install-GalaxyBookEnabler.ps1 -TestMode
-    Runs in test mode without applying registry changes, creating tasks, or installing packages.
+.\Install-GalaxyBookEnabler.ps1 -TestMode
 
 .EXAMPLE
-    irm https://raw.githubusercontent.com/Bananz0/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | iex
-    Installs in one line from GitHub.
+irm https://raw.githubusercontent.com/Chiragsd13/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | iex
 
 .NOTES
-    File Name      : Install-GalaxyBookEnabler.ps1
-    Prerequisite   : PowerShell 7.0 or later
-    Requires Admin : Yes
-    Version        : 3.2.0
-    Repository     : https://github.com/Bananz0/GalaxyBookEnabler
-    Patch Author   : Chirag Sood <chiragsd13@gmail.com>
-    Patch Notes    : v3.2.0 - Added Galaxy Book6 Ultra/Pro (960XKB/960XKA), AMD Ryzen
-                     support, CPU/Wi-Fi/BT platform detection, hardware compatibility
-                     report, and updated model selection menu.
+File Name  : Install-GalaxyBookEnabler.ps1
+Prerequisite : PowerShell 7.0 or later
+Requires Admin : Yes
+Version : 3.2.0
+Repository : https://github.com/Chiragsd13/GalaxyBookEnabler
+Patch Author : Chirag Sood
 #>
 
 param(
@@ -262,7 +221,7 @@ if (-not $isAdmin) {
 
 # VERSION CONSTANT
 $SCRIPT_VERSION = "3.2.0"
-$GITHUB_REPO = "Bananz0/GalaxyBookEnabler"
+$GITHUB_REPO = "Chiragsd13/GalaxyBookEnabler"
 $UPDATE_CHECK_URL = "https://api.github.com/repos/$GITHUB_REPO/releases/latest"
 
 # LOGGING SETUP

--- a/README.md
+++ b/README.md
@@ -2,32 +2,33 @@
 
 > Enable Samsung Galaxy Book features on any Windows PC
 
-[![Version](https://img.shields.io/badge/version-3.1.0-blue.svg)](https://github.com/Bananz0/GalaxyBookEnabler)
+[![Version](https://img.shields.io/badge/version-3.2.0-blue.svg)](https://github.com/Chiragsd13/GalaxyBookEnabler)
 [![License](https://img.shields.io/badge/license-MIT-green.svg)](LICENSE)
 [![PowerShell](https://img.shields.io/badge/PowerShell-7.0%2B-blue.svg)](https://github.com/PowerShell/PowerShell)
 [![Windows 11](https://img.shields.io/badge/Windows-11-0078D4.svg?logo=windows11)](https://www.microsoft.com/windows/windows-11)
-[![SSSE Support](https://img.shields.io/badge/SSSE-Integrated-purple.svg)](https://github.com/Bananz0/GalaxyBookEnabler)
-[![CodeFactor](https://www.codefactor.io/repository/github/bananz0/galaxybookenabler/badge)](https://www.codefactor.io/repository/github/bananz0/galaxybookenabler)
-![View Count](https://komarev.com/ghpvc/?username=Bananz0&repo=GalaxyBookEnabler&color=brightgreen)
-![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/bananz0/GalaxyBookEnabler/total)
-
-> 🎉 A big thank you to [@Hydro3ia](https://github.com/Hydro3ia), [@systemsrethinking](https://github.com/systemsrethinking) and [@intini](https://github.com/intini) for sponsoring us! ❤️
+[![SSSE Support](https://img.shields.io/badge/SSSE-Integrated-purple.svg)](https://github.com/Chiragsd13/GalaxyBookEnabler)
+[![CodeFactor](https://www.codefactor.io/repository/github/chiragsd13/galaxybookenabler/badge)](https://www.codefactor.io/repository/github/chiragsd13/galaxybookenabler)
+![View Count](https://komarev.com/ghpvc/?username=Chiragsd13&repo=GalaxyBookEnabler&color=brightgreen)
+![GitHub Downloads (all assets, all releases)](https://img.shields.io/github/downloads/Chiragsd13/GalaxyBookEnabler/total)
 
 ## Overview
 
-Galaxy Book Enabler spoofs your Windows PC as a Samsung Galaxy Book, unlocking access to Samsung's ecosystem apps like Quick Share, Multi Control, Samsung Notes, and more. The tool provides an intelligent installer with package filtering, Wi-Fi compatibility detection, and automated startup configuration.
+Galaxy Book Enabler spoofs your Windows PC as a Samsung Galaxy Book, unlocking access to Samsung's ecosystem apps like Quick Share, Multi Control, Samsung Notes, and more. The tool provides an intelligent installer with package filtering, hardware compatibility detection, diagnostic logging, and automated startup configuration.
 
-> **See what's new:** [Changelog](CHANGELOG.md) | [Releases](https://github.com/Bananz0/GalaxyBookEnabler/releases)
+> **See what's new:** [Changelog](CHANGELOG.md) | [Releases](https://github.com/Chiragsd13/GalaxyBookEnabler/releases)
 
 ## Features
 
-- **21 Galaxy Book Models** - Choose from authentic hardware profiles (Galaxy Book3/4/5, Pro, Ultra, 360)
+- **23 Galaxy Book Models** - Choose from authentic hardware profiles across Galaxy Book6/5/4/3 and legacy families
+- **New Galaxy Book6 2026 Profiles** - Includes Galaxy Book6 Ultra (`960XKB`) and Galaxy Book6 Pro (`960XKA`)
+- **AMD Ryzen Support** - Better guidance and profile recommendations for AMD systems
+- **Hardware Compatibility Report** - Detects CPU, Wi-Fi, and Bluetooth platforms before install and shows a feature support summary
+- **Vendor-ID-Based Detection** - Language-independent Wi-Fi and Bluetooth detection for more reliable compatibility checks
 - **Samsung MultiPoint Support** - Connect Galaxy Buds to multiple devices seamlessly via Samsung Settings app
 - **Auto-Elevation** - Automatically requests admin rights (supports gsudo and Windows 11 native sudo)
-- **Diagnostic Logging** - Automatic log generation for troubleshooting (saved to %TEMP%, works even with one-line install)
+- **Diagnostic Logging** - Automatic log generation for troubleshooting (saved to `%TEMP%`, works even with one-line install)
 - **Smart Package Selection** - Choose from Core, Recommended, Full Experience, or custom package combinations
 - **Package Manager** - Install or uninstall entire profiles from existing installations with status tracking
-- **Wi-Fi Compatibility Check** - Automatically detects Intel Wi-Fi adapters and warns about Quick Share limitations
 - **System Support Engine (Advanced)** - Optional experimental feature for enhanced Samsung integration (Windows 11 only)
 - **Automated Startup** - Registry spoof runs automatically on every boot
 - **Multi Control Recovery Task** - Restarts Samsung services at startup (+5 min) with a 1-minute grace period to improve Multi Control/phone reconnection reliability
@@ -48,11 +49,11 @@ Windows comes with PowerShell 5.1 by default, which is **NOT compatible**. You m
 ```powershell
 # Install PowerShell 7 (one-time setup)
 winget install Microsoft.PowerShell
-```
+````
 
 **Note:** If this is your first time using `winget`, you may need to run `winget list` first to accept the source agreements. The command may appear to stall without this step.
 
-Or download from: <https://aka.ms/powershell>
+Or download from: [https://aka.ms/powershell](https://aka.ms/powershell)
 
 After installing, use `pwsh` (PowerShell 7) instead of `powershell` (Windows PowerShell 5.1).
 
@@ -62,7 +63,7 @@ After installing, use `pwsh` (PowerShell 7) instead of `powershell` (Windows Pow
 
 ```powershell
 # Run in PowerShell 7 (pwsh)
-irm https://raw.githubusercontent.com/Bananz0/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | iex
+irm https://raw.githubusercontent.com/Chiragsd13/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | iex
 ```
 
 *The installer will automatically request administrator privileges if needed.*
@@ -71,11 +72,12 @@ irm https://raw.githubusercontent.com/Bananz0/GalaxyBookEnabler/main/Install-Gal
 
 When running the installer on an existing installation, you have granular uninstall options:
 
-- **Reinstall (nuke + fresh install)**: Completely removes everything (preserving BIOS config), then performs a clean installation
-- **Uninstall everything**: Removes all Samsung apps, services, scheduled tasks, and configuration
-  - **Nuke Mode**: Optionally delete ALL Samsung app data (caches, settings, databases) during uninstall
-- **Uninstall apps only**: Removes all installed Samsung apps while keeping services and scheduled tasks
-- **Uninstall services only**: Removes scheduled tasks and Samsung services while keeping apps installed
+* **Reinstall (nuke + fresh install)**: Completely removes everything (preserving BIOS config), then performs a clean installation
+* **Uninstall everything**: Removes all Samsung apps, services, scheduled tasks, and configuration
+
+  * **Nuke Mode**: Optionally delete ALL Samsung app data (caches, settings, databases) during uninstall
+* **Uninstall apps only**: Removes all installed Samsung apps while keeping services and scheduled tasks
+* **Uninstall services only**: Removes scheduled tasks and Samsung services while keeping apps installed
 
 **With gsudo (recommended for seamless elevation):**
 
@@ -84,7 +86,7 @@ When running the installer on an existing installation, you have granular uninst
 winget install gerardog.gsudo
 
 # Then install Galaxy Book Enabler with automatic elevation
-irm https://raw.githubusercontent.com/Bananz0/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | gsudo pwsh
+irm https://raw.githubusercontent.com/Chiragsd13/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | gsudo pwsh
 ```
 
 ### Manual Install
@@ -93,6 +95,13 @@ irm https://raw.githubusercontent.com/Bananz0/GalaxyBookEnabler/main/Install-Gal
 2. Run: `.\Install-GalaxyBookEnabler.ps1`
 3. Accept UAC prompt when requested
 4. Follow the interactive installer
+
+Or use:
+
+```powershell
+iwr https://raw.githubusercontent.com/Chiragsd13/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 -OutFile Install-GalaxyBookEnabler.ps1
+pwsh .\Install-GalaxyBookEnabler.ps1
+```
 
 *No need to manually "Run as Administrator" - the script handles elevation automatically!*
 
@@ -128,23 +137,24 @@ Run the installer non-interactively with all options specified up front:
 ```
 
 Notes:
-- `-AutonomousPackageProfile` supports: `Core`, `Recommended`, `RecommendedPlus`, `Full`, `Everything`, `Custom`, `Skip`.
-- For `Custom`, pass `-AutonomousPackageNames` with package names/IDs.
-- `-AutonomousModel` must match a model code from the model list (e.g., `960XGL`, `960XGK`).
-- `-AutonomousAction` supports: `Install` (default), `UpdateSettings`, `UpgradeSSE`, `UninstallAll`, `Cancel`.
-- Logs default to `C:\GalaxyBook\Logs` in autonomous mode unless `-LogPath` or `-LogDirectory` is supplied.
+
+* `-AutonomousPackageProfile` supports: `Core`, `Recommended`, `RecommendedPlus`, `Full`, `Everything`, `Custom`, `Skip`
+* For `Custom`, pass `-AutonomousPackageNames` with package names/IDs
+* `-AutonomousModel` must match a model code from the model list (e.g. `960XGL`, `960XGK`, `960XKA`)
+* `-AutonomousAction` supports: `Install` (default), `UpdateSettings`, `UpgradeSSE`, `UninstallAll`, `Cancel`
+* Logs default to `C:\GalaxyBook\Logs` in autonomous mode unless `-LogPath` or `-LogDirectory` is supplied
 
 ## Reset & Repair Tools
 
 The installer includes a comprehensive suite of tools to fix common issues with Samsung apps. Select **"Reset/Repair Samsung Apps"** from the main menu (or uninstall menu) to access:
 
-- **Diagnostics**: Checks installed packages, device data files, and databases
-- **Soft Reset**: Clears app caches and temporary files (preserves login)
-- **Hard Reset**: Clears caches, device data, and settings (requires re-login)
-- **Clear Authentication**: Removes Samsung Account database and credentials
-- **Repair Permissions**: Fixes ACLs on app folders
-- **Re-register Apps**: Re-registers AppX manifests to fix launch issues
-- **Factory Reset**: Completely wipes ALL Samsung data (credentials, devices, DBs, settings)
+* **Diagnostics**: Checks installed packages, device data files, and databases
+* **Soft Reset**: Clears app caches and temporary files (preserves login)
+* **Hard Reset**: Clears caches, device data, and settings (requires re-login)
+* **Clear Authentication**: Removes Samsung Account database and credentials
+* **Repair Permissions**: Fixes ACLs on app folders
+* **Re-register Apps**: Re-registers AppX manifests to fix launch issues
+* **Factory Reset**: Completely wipes ALL Samsung data (credentials, devices, DBs, settings)
 
 ## Package Profiles
 
@@ -152,51 +162,51 @@ The installer includes a comprehensive suite of tools to fix common issues with 
 
 Essential packages for basic Samsung ecosystem functionality:
 
-- Samsung Account
-- Samsung Settings + Runtime
-- Samsung Cloud
-- Knox Matrix for Windows
-- Samsung Continuity Service
-- Samsung Intelligence Service
-- Samsung Bluetooth Sync
-- Galaxy Book Experience
+* Samsung Account
+* Samsung Settings + Runtime
+* Samsung Cloud
+* Knox Matrix for Windows
+* Samsung Continuity Service
+* Samsung Intelligence Service
+* Samsung Bluetooth Sync
+* Galaxy Book Experience
 
 ### Recommended
 
 Core packages + all fully working Samsung apps:
 
-- Quick Share (requires Intel Wi-Fi for best results)
-- Samsung Notes
-- Multi Control
-- Samsung Gallery
-- Samsung Studio + Studio for Gallery
-- Samsung Screen Recorder
-- Samsung Flow
-- SmartThings
-- Galaxy Buds Manager
-- Samsung Parental Controls
-- AI Select
-- Nearby Devices
-- Storage Share
-- Second Screen
-- Live Wallpaper
-- Galaxy Book Smart Switch
-- Samsung Pass
+* Quick Share (requires Intel Wi-Fi for best results)
+* Samsung Notes
+* Multi Control
+* Samsung Gallery
+* Samsung Studio + Studio for Gallery
+* Samsung Screen Recorder
+* Samsung Flow
+* SmartThings
+* Galaxy Buds Manager
+* Samsung Parental Controls
+* AI Select
+* Nearby Devices
+* Storage Share
+* Second Screen
+* Live Wallpaper
+* Galaxy Book Smart Switch
+* Samsung Pass
 
 ### Full Experience
 
 Recommended + apps requiring extra configuration:
 
-- Samsung Phone (needs additional setup)
-- Samsung Find (needs additional setup)
-- Quick Search (needs additional setup)
+* Samsung Phone (needs additional setup)
+* Samsung Find (needs additional setup)
+* Quick Search (needs additional setup)
 
 ### Everything
 
 All packages including non-functional ones:
 
-- ⚠️ Samsung Recovery (won't work)
-- ⚠️ Samsung Update (won't work)
+* ⚠️ Samsung Recovery (won't work)
+* ⚠️ Samsung Update (won't work)
 
 ### Custom Selection
 
@@ -204,588 +214,193 @@ Pick individual packages by category with detailed descriptions and warnings.
 
 ## Package Compatibility Matrix
 
-| Package | Status | Intel Wi-Fi AX + BT Required | Notes |
-|---------|--------|------------------------------|-------|
-| Samsung Account | ✅ Working | No | Required |
-| Samsung Settings | ✅ Working | No | Required |
-| Samsung Settings Runtime | ✅ Working | No | Required |
-| Samsung Cloud Assistant | ✅ Working | No | Required |
-| Samsung Continuity Service | ✅ Working | No | Required |
-| Samsung Intelligence Service | ✅ Working | No | Required (AI features) |
-| Samsung Bluetooth Sync | ✅ Working | No | Required |
-| Galaxy Book Experience | ✅ Working | No | Core (app catalog) |
-| Quick Share | ✅ Working | **Yes** | Requires Intel Wi-Fi AX + Intel Bluetooth |
-| Camera Share | ✅ Working |**Yes**| Requires Intel Wi-Fi AX + Intel Bluetooth |
-| Samsung Notes | ✅ Working | No | - |
-| Multi Control | 🔍 Investigating | **Yes** | Under investigation - works intermittently, not reliable on any Wi-Fi |
-| Samsung Gallery | ✅ Working | No | - |
-| Samsung Studio | ✅ Working | No | - |
-| Samsung Studio for Gallery | ✅ Working | No | - |
-| Samsung Screen Recorder | ⚠️ Working | No | Shows "optimized for Galaxy Books" |
-| Samsung Flow | ✅ Working | No | - |
-| SmartThings | ✅ Working | No | - |
-| Galaxy Buds | ✅ Working | No | - |
-| Samsung Parental Controls | ✅ Working | No | - |
-| AI Select | ✅ Working | No | - |
-| Nearby Devices | ✅ Working | No | - |
-| Storage Share | ✅ Working | No | - |
-| Second Screen | ⚠️ Limited | **Yes** | Works on Wi-Fi 6/6E/7 (AX/BE), not on Wi-Fi 5 (AC) |
-| Live Wallpaper | ✅ Working | No | - |
-| Galaxy Book Smart Switch | ✅ Working | No | - |
-| Samsung Pass | ✅ Working | No | - |
-| Samsung Device Care | ⚠️ Extra Steps | No | May not function properly |
-| Samsung Phone | ⚠️ Extra Steps | No | Configuration required |
-| Samsung Find | ⚠️ Extra Steps | No | Configuration required |
-| Quick Search | ⚠️ Extra Steps | No | Configuration required |
-| Samsung Recovery | ❌ Not Working | No | Requires genuine hardware |
-| Samsung Update | ❌ Not Working | No | Requires genuine hardware |
+| Package                      | Status           | Intel Wi-Fi + BT Required for Full Support | Notes                                                                  |
+| ---------------------------- | ---------------- | ------------------------------------------ | ---------------------------------------------------------------------- |
+| Samsung Account              | ✅ Working        | No                                         | Required                                                               |
+| Samsung Settings             | ✅ Working        | No                                         | Required                                                               |
+| Samsung Settings Runtime     | ✅ Working        | No                                         | Required                                                               |
+| Samsung Cloud Assistant      | ✅ Working        | No                                         | Required                                                               |
+| Samsung Continuity Service   | ✅ Working        | No                                         | Core service works; continuity reliability is best on Intel Wi-Fi + BT |
+| Samsung Intelligence Service | ✅ Working        | No                                         | Required (AI features)                                                 |
+| Samsung Bluetooth Sync       | ✅ Working        | No                                         | Required                                                               |
+| Galaxy Book Experience       | ✅ Working        | No                                         | Core (app catalog)                                                     |
+| Quick Share                  | ✅ Working        | **Yes**                                    | Requires Intel Wi-Fi + Intel Bluetooth                                 |
+| Camera Share                 | ✅ Working        | **Yes**                                    | Requires Intel Wi-Fi + Intel Bluetooth                                 |
+| Samsung Notes                | ✅ Working        | No                                         | -                                                                      |
+| Multi Control                | 🔍 Investigating | **Yes**                                    | Under investigation; full reliability requires Intel Wi-Fi + BT        |
+| Samsung Gallery              | ✅ Working        | No                                         | -                                                                      |
+| Samsung Studio               | ✅ Working        | No                                         | -                                                                      |
+| Samsung Studio for Gallery   | ✅ Working        | No                                         | -                                                                      |
+| Samsung Screen Recorder      | ⚠️ Working       | No                                         | Shows "optimized for Galaxy Books"                                     |
+| Samsung Flow                 | ✅ Working        | No                                         | -                                                                      |
+| SmartThings                  | ✅ Working        | No                                         | -                                                                      |
+| Galaxy Buds                  | ✅ Working        | No                                         | MultiPoint supported via Samsung Settings                              |
+| Samsung Parental Controls    | ✅ Working        | No                                         | -                                                                      |
+| AI Select                    | ✅ Working        | No                                         | -                                                                      |
+| Nearby Devices               | ✅ Working        | No                                         | -                                                                      |
+| Storage Share                | ⚠️ Limited       | **Yes**                                    | Best with Intel Wi-Fi + Intel Bluetooth                                |
+| Second Screen                | ⚠️ Limited       | **Yes**                                    | Best with Intel Wi-Fi + Intel Bluetooth                                |
+| Live Wallpaper               | ✅ Working        | No                                         | -                                                                      |
+| Galaxy Book Smart Switch     | ✅ Working        | No                                         | -                                                                      |
+| Samsung Pass                 | ✅ Working        | No                                         | -                                                                      |
+| Samsung Device Care          | ⚠️ Extra Steps   | No                                         | May not function properly                                              |
+| Samsung Phone                | ⚠️ Extra Steps   | No                                         | Configuration required                                                 |
+| Samsung Find                 | ⚠️ Extra Steps   | No                                         | Configuration required                                                 |
+| Quick Search                 | ⚠️ Extra Steps   | No                                         | Configuration required                                                 |
+| Samsung Recovery             | ❌ Not Working    | No                                         | Requires genuine hardware                                              |
+| Samsung Update               | ❌ Not Working    | No                                         | Requires genuine hardware                                              |
 
 ## System Requirements
 
 ### Required
 
-- Windows 10/11 (64-bit)
-- PowerShell 7.0 or later
-- Administrator privileges
-- Active Internet connection
+* Windows 10/11 (64-bit)
+* PowerShell 7.0 or later
+* Administrator privileges
+* Active Internet connection
 
 ### Recommended for Full Experience
 
-- Intel Wi-Fi adapter (for Quick Share)
-- 8GB RAM or more
-- Samsung account
+* Intel Wi-Fi adapter (for Quick Share and related Wi-Fi Direct features)
+* Intel Bluetooth adapter
+* 8GB RAM or more
+* Samsung account
 
 ### System Support Engine (Optional Advanced Feature)
 
-- **Windows 11 (Build 22000+)** - Required
-- **x64 architecture** - ARM not supported
-- **Advanced users only** - Involves binary patching and service creation
-- **Experimental** - May cause system instability or trigger antivirus warnings
+* **Windows 11 (Build 22000+)** - Required
+* **x64 architecture** - Recommended
+* **ARM** - Experimental warning shown, not officially supported
+* **Advanced users only** - Involves binary patching and service creation
+* **Experimental** - May cause system instability or trigger antivirus warnings
 
 ## Wi-Fi & Bluetooth Compatibility
 
-Samsung apps require **Intel Wi-Fi** and **Intel Bluetooth** adapters for full wireless features. Compatibility varies by Wi-Fi generation:
+Galaxy Book Enabler now performs a **hardware compatibility check before installation**. The installer detects your **CPU**, **Wi-Fi**, and **Bluetooth** platforms and shows a feature support summary before you choose a profile.
+
+### Detected Hardware Platforms
+
+#### CPU detection
+
+* **Intel** - Full support
+* **AMD Ryzen** - Supported for many apps and features, with hardware-dependent limitations for some wireless features
+* **ARM** - Experimental warning shown during install
+
+#### Wi-Fi detection
+
+The installer checks vendor IDs for:
+
+* **Intel** (`8086`)
+* **MediaTek / AMD RZ-series** (`14C3`)
+* **Realtek** (`10EC`)
+* **Qualcomm** (`168C`, `17CB`)
+
+#### Bluetooth detection
+
+The installer checks vendor IDs for:
+
+* **Intel** (`8087`)
+* **MediaTek** (`0E8D`)
+* **Realtek** (`0BDA`)
+
+### Feature Support Summary
+
+* **Samsung Notes / Bixby / AI Select** - Works regardless of Wi-Fi platform
+* **Galaxy Buds / MultiPoint** - Works regardless of Wi-Fi platform
+* **Samsung Settings / Knox / Pass** - Works regardless of Wi-Fi platform
+* **Quick Share / Camera Share / Storage Share** - Require Intel Wi-Fi for full support
+* **Multi Control / Second Screen** - Most reliable with Intel Wi-Fi + Intel Bluetooth
+* **Continuity Service** - Best results with Intel Wi-Fi + Intel Bluetooth
+
+### AMD Ryzen Systems
+
+AMD systems are supported, but the best experience depends heavily on the Wi-Fi and Bluetooth chipset in the machine.
+
+* If your AMD system has **Intel Wi-Fi + Intel Bluetooth**, wireless Samsung features have the best chance of working properly
+* If your AMD system uses **MediaTek**, **Realtek**, or **Qualcomm** Wi-Fi, expect **Samsung Notes**, **Galaxy Buds**, **Samsung Settings**, **Knox**, and similar apps to work, but **Quick Share**, **Camera Share**, and **Storage Share** are not expected to work correctly
+* For AMD systems, the installer guidance currently favors **Galaxy Book5 Pro (`960XHA`)** or **Galaxy Book6 Pro (`960XKA`)** profiles
 
 ### Wi-Fi Compatibility by Generation
 
-| Generation | Adapters | Quick Share | Multi Control | Second Screen | Camera Share | Storage Share |
-|------------|----------|-------------|---------------|---------------|--------------|---------------|
-| **Wi-Fi 7 (BE)** | BE200, BE201, BE202 | ✅ Full | 🔍 Investigating | ✅ Full | ✅ Full | ✅ Full |
-| **Wi-Fi 6E (AX)** | AX210, AX211, AX411 | ✅ Full | 🔍 Investigating | ✅ Full | ✅ Full | ✅ Full |
-| **Wi-Fi 6 (AX)** | AX201, AX200 | ✅ Full | 🔍 Investigating | ✅ Full | ✅ Full | ✅ Full |
-| **Wi-Fi 5 (AC)** | 9260, 9560, 8265, 8260 | ✅ Works | ❌ Not Working | ❌ Not Working | ✅ Works | ✅ Works |
-| **Wireless-AC (Legacy)** | 7265, 7260, 3168, 3165 | ❓ Not Tested | ❌ Not Working | ❌ Not Working | ❓ Not Tested | ❓ Not Tested |
-| **Non-Intel** | Realtek, MediaTek, Qualcomm | ❌ | ❌ | ❌ | ❌ | ❌ |
+The table below focuses on the wireless Samsung features that depend on Wi-Fi Direct and related stack behavior.
+
+| Generation               | Adapters                    | Quick Share  | Multi Control    | Second Screen | Camera Share | Storage Share |
+| ------------------------ | --------------------------- | ------------ | ---------------- | ------------- | ------------ | ------------- |
+| **Wi-Fi 7 (BE)**         | BE200, BE201, BE202         | ✅ Full       | 🔍 Investigating | ✅ Full        | ✅ Full       | ✅ Full        |
+| **Wi-Fi 6E (AX)**        | AX210, AX211, AX411         | ✅ Full       | 🔍 Investigating | ✅ Full        | ✅ Full       | ✅ Full        |
+| **Wi-Fi 6 (AX)**         | AX201, AX200                | ✅ Full       | 🔍 Investigating | ✅ Full        | ✅ Full       | ✅ Full        |
+| **Wi-Fi 5 (AC)**         | 9260, 9560, 8265, 8260      | ✅ Works      | ❌ Not Working    | ❌ Not Working | ✅ Works      | ✅ Works       |
+| **Wireless-AC (Legacy)** | 7265, 7260, 3168, 3165      | ❓ Not Tested | ❌ Not Working    | ❌ Not Working | ❓ Not Tested | ❓ Not Tested  |
+| **Non-Intel**            | Realtek, MediaTek, Qualcomm | ❌            | ❌ / Limited      | ❌ / Limited   | ❌            | ❌             |
 
 ### Intel Wi-Fi Product Families
 
 #### Wi-Fi 7 (BE) - Full Compatibility ✅
 
-| Product | Launch | Max Speed | Notes |
-|---------|--------|-----------|-------|
-| Intel Wi-Fi 7 BE200 | Q3'23 | 5.8 Gbps | 320 MHz, 4096 QAM |
-| Intel Wi-Fi 7 BE201 | Q2'24 | 5.8 Gbps | Double Connect Technology |
-| Intel Wi-Fi 7 BE202 | Q3'23 | 2.4 Gbps | 160 MHz, 1024 QAM |
+| Product             | Launch | Max Speed | Notes                     |
+| ------------------- | ------ | --------- | ------------------------- |
+| Intel Wi-Fi 7 BE200 | Q3'23  | 5.8 Gbps  | 320 MHz, 4096 QAM         |
+| Intel Wi-Fi 7 BE201 | Q2'24  | 5.8 Gbps  | Double Connect Technology |
+| Intel Wi-Fi 7 BE202 | Q3'23  | 2.4 Gbps  | 160 MHz, 1024 QAM         |
 
 #### Wi-Fi 6E (AX) - Full Compatibility ✅
 
-| Product | Launch | Max Speed | Notes |
-|---------|--------|-----------|-------|
-| Intel Wi-Fi 6E AX411 (Gig+) | Q4'21 | ~3.0 Gbps | Double Connect Technology |
-| Intel Wi-Fi 6E AX211 (Gig+) | Q3'21 | 2.4 Gbps | Most common 6E adapter |
-| Intel Wi-Fi 6E AX210 (Gig+) | Q4'20 | 2.4 Gbps | First consumer 6E |
+| Product                     | Launch | Max Speed | Notes                     |
+| --------------------------- | ------ | --------- | ------------------------- |
+| Intel Wi-Fi 6E AX411 (Gig+) | Q4'21  | ~3.0 Gbps | Double Connect Technology |
+| Intel Wi-Fi 6E AX211 (Gig+) | Q3'21  | 2.4 Gbps  | Most common 6E adapter    |
+| Intel Wi-Fi 6E AX210 (Gig+) | Q4'20  | 2.4 Gbps  | First consumer 6E         |
 
 #### Wi-Fi 6 (AX) - Full Compatibility ✅
 
-- Intel Wi-Fi 6 AX201/AX200
-- Intel Killer Wi-Fi 6 variants
+* Intel Wi-Fi 6 AX201/AX200
+* Intel Killer Wi-Fi 6 variants
 
 #### Wi-Fi 5 / Wireless-AC - Limited Compatibility ⚠️
 
-| Product Family | Quick Share | Multi Control | Second Screen |
-|----------------|-------------|---------------|---------------|
-| Intel Wireless-AC 9000 Series (9260, 9560) | ✅ Works | ❌ No | ❌ No |
-| Intel Wireless-AC 8000 Series (8265, 8260) | ✅ Works | ❌ No | ❌ No |
+| Product Family                             | Quick Share | Multi Control | Second Screen |
+| ------------------------------------------ | ----------- | ------------- | ------------- |
+| Intel Wireless-AC 9000 Series (9260, 9560) | ✅ Works     | ❌ No          | ❌ No          |
+| Intel Wireless-AC 8000 Series (8265, 8260) | ✅ Works     | ❌ No          | ❌ No          |
 
 **AC Limitations:**
-- Multi Control does not work
-- Second Screen does not work (WiFi Direct uses 802.11n - Samsung limitation)
-- May show "A software or driver update is required" error in Quick Share
+
+* Multi Control does not work reliably
+* Second Screen does not work
+* Quick Share may show driver or software update errors on some systems
 
 #### Legacy Wireless-AC - Not Tested ❓
 
-| Product Family | Status |
-|----------------|--------|
+| Product Family              | Status                    |
+| --------------------------- | ------------------------- |
 | Intel Wireless-AC 7265/7260 | Not tested - may not work |
 | Intel Wireless-AC 3168/3165 | Not tested - may not work |
 
 > **⚠️ Legacy Warning**: These older adapters may not work if:
-> - Driver hasn't been updated since 2020 (e.g., Windows 8.1 drivers v21.40.5)
-> - Product is discontinued without Windows 10/11 driver support
-> - Adapter doesn't support modern Wi-Fi Direct features
+>
+> * Driver hasn't been updated since 2020
+> * Product is discontinued without Windows 10/11 driver support
+> * Adapter doesn't support modern Wi-Fi Direct features
 
 ### Multi Control Status: Under Investigation 🔍
 
-Multi Control is currently **not working reliably** on any Intel Wi-Fi generation:
-- Works intermittently on Wi-Fi 6/6E/7
-- Completely non-functional on Wi-Fi 5 (AC)
-- Investigation ongoing - may be Samsung server-side issue
+Multi Control is currently **not working reliably** on any platform:
 
-### Non-Intel Wi-Fi (Not Working) ❌
+* Works intermittently on some Intel Wi-Fi 6/6E/7 systems
+* Completely unreliable on many non-Intel setups
+* Investigation is ongoing
 
-- Realtek adapters
-- MediaTek adapters
-- Qualcomm adapters
-- Broadcom adapters
+### Intel Bluetooth (Required for Full Wireless Features) ✅
 
-### Intel Bluetooth (Required) ✅
-
-All wireless features also require an **Intel Bluetooth radio** (not just Wi-Fi). Third-party Bluetooth adapters (USB dongles, etc.) will cause features to fail with unhelpful errors.
+All major wireless features also require an **Intel Bluetooth radio** in addition to compatible Wi-Fi. Third-party Bluetooth adapters and mismatched wireless stacks may cause features to fail with unclear errors.
 
 ### Alternative for Non-Intel Users
 
 If you don't have Intel Wi-Fi **and** Intel Bluetooth, consider **Google Nearby Share** as an alternative:
 
-- Works with any Wi-Fi adapter
-- Similar file-sharing functionality
-- Cross-platform support (Windows, Android, ChromeOS)
-- Download: [Google Nearby Share](https://www.android.com/better-together/nearby-share-app/)
-
-## AI Select (Smart Select)
-
-AI Select is Samsung's intelligent selection tool. The installer creates launcher scripts in `C:\GalaxyBook\` for easy hotkey binding.
-
-### Launch URI
-
-```shell
-shell:AppsFolder\SAMSUNGELECTRONICSCO.LTD.SmartSelect_3c1yjt4zspk6g!App
-```
-
-### Method 1: PowerToys URI (Recommended - Fastest)
-
-This method launches AI Select instantly with a single key press:
-
-1. Install [PowerToys](https://aka.ms/getPowerToys) from Microsoft Store
-2. Open PowerToys → Keyboard Manager
-3. **Remap a key** (e.g., `Right Alt` → `Win+Ctrl+Alt+S`)
-   - This creates an unused intermediate shortcut
-4. **Remap a shortcut** → `Win+Ctrl+Alt+S` → **Open URI**
-   - URI: `shell:AppsFolder\SAMSUNGELECTRONICSCO.LTD.SmartSelect_3c1yjt4zspk6g!App`
-5. Press Right Alt to instantly launch AI Select!
-
-### Method 2: PowerToys Run Program
-
-1. Install PowerToys
-2. Keyboard Manager → Remap a shortcut
-3. Set shortcut (e.g., `Ctrl+Shift+S`) → Action: **Run Program**
-4. Program: `powershell.exe`
-5. Args: `-WindowStyle Hidden -File "C:\GalaxyBook\AISelect.ps1"`
-
-### Method 3: AutoHotkey (AHK)
-
-For advanced users who prefer AutoHotkey:
-
-```autohotkey
-; AI Select launcher - save as AISelect.ahk
-#Requires AutoHotkey v2.0
-
-; Press Right Alt to launch AI Select
-RAlt::Run "shell:AppsFolder\SAMSUNGELECTRONICSCO.LTD.SmartSelect_3c1yjt4zspk6g!App"
-```
-
-### Method 4: Desktop Shortcut (Standard)
-
-1. Find the "AI Select.lnk" on your Desktop (created by installer)
-2. Right-click → Properties
-3. Click in the "Shortcut key" field
-4. Press your desired key combination (e.g., Ctrl+Alt+S)
-5. Click OK
-
-> **Note:** Desktop shortcuts use explorer.exe which adds slight overhead. PowerToys URI or AHK methods are faster.
-
-### Manual Identity Generation
-
-If you need to generate high-fidelity DMI strings manually for OpenCore or generic spoofing, use the provided utility:
-
-```powershell
-.\Generate-SamsungIdentity.ps1 -Profile Book6Ultra -IncludeFullBiosVersion
-.\Generate-SamsungIdentity.ps1 -Profile Book6Pro -IncludeFullBiosVersion -WriteConfigPlist -ConfigPath "D:\\EFI\\OC\\config.plist"
-```
-
-This generates randomized but internally consistent `SystemSKU`, `BIOSVersion`, `SerialNumber`, `ROM`, and `SystemUUID` values using Samsung's documented patterns. It also derives `BoardProduct` from randomized model/suffix pairs.
-
-When `-WriteConfigPlist` is used, the script creates a timestamped `.bak` copy alongside the original file before writing updates.
-
-**Region selection** defaults to your Windows locale. Ireland (`IE`) maps to the UK (`UK`) by default. If you need a closer match, set `-CountryCode` or `-RegionCode`. Optional `-UseGeoIp` uses the public ipapi.co endpoint (no API key) to resolve country based on IP. This can affect region-locked features; for example, Samsung Phone app Messages has been observed to be available in the US but not in the UK.
-
-## 🔧 How It Works
-
-1. **Registry Spoof**: Modifies system registry to identify as "Samsung Galaxy Book3 Ultra"
-2. **Startup Tasks**: Creates scheduled tasks that run on every boot
-3. **Multi Control Recovery**: Runs `Init-SamsungMultiControlOnLogin.ps1` at startup +5 minutes, then waits 1 minute before restarting Samsung services
-4. **Package Installation**: Installs selected Samsung apps from Microsoft Store
-5. **Configuration**: Sets up shortcuts and configuration files
-
-**Available Models**
-
-| Model   | Family                              | Gen  |
-|---------|-------------------------------------|------|
-| 960XKB  | Galaxy Book6 Ultra                  | 2026 |
-| 960XKA  | Galaxy Book6 Pro                    | 2026 |
-| 960XHA  | Galaxy Book5 Pro                    | 2025 |
-| 940XHA  | Galaxy Book5 Pro                    | 2025 |
-| 960QHA  | Galaxy Book5 Pro 360                | 2025 |
-| 750QHA  | Galaxy Book5 360                    | 2025 |
-| 960XGL  | Galaxy Book4 Ultra                  | 2024 |
-| 960XGK  | Galaxy Book4 Pro                    | 2024 |
-| 940XGK  | Galaxy Book4 Pro                    | 2024 |
-| 960QGK  | Galaxy Book4 Pro 360                | 2024 |
-| 750XGK  | Galaxy Book4                        | 2024 |
-| 750XGL  | Galaxy Book4                        | 2024 |
-| 750QGK  | Galaxy Book4 360                    | 2024 |
-| 960XFH  | Galaxy Book3 Ultra                  | 2023 |
-| 960XFG  | Galaxy Book3 Pro                    | 2023 |
-| 960QFG  | Galaxy Book3 Pro 360                | 2023 |
-| 750XFG  | Galaxy Book3                        | 2023 |
-| 750XFH  | Galaxy Book3                        | 2023 |
-| 730QFG  | Galaxy Book3 360                    | 2023 |
-| 950XGK  | Galaxy Book2 Pro Special Edition    | 2022 |
-| 930XDB  | Galaxy Book Series                  | 2021 |
-| 935QDC  | Galaxy Book Series                  | 2021 |
-| 930SBE  | Notebook 9 Series                   | 2020 |
-
-**How Model Selection Works:**
-
-1. During installation, you'll see a categorized menu of all 21 models
-2. Models are grouped by generation (Book5 > Book4 > Book3 > Book2)
-3. Each model has authentic BIOS/DMI values extracted from real hardware
-4. Select your preferred model to spoof
-5. All 11 registry values are automatically configured
-
-**Example Selection:**
-
-```preview
-========================================
-  Select Galaxy Book Model to Spoof
-========================================
-
-Available Models:
-
-  Galaxy Book5:
-     1. 960XHA - Galaxy Book5 Pro
-     2. 940XHA - Galaxy Book5 Pro
-     3. 960QHA - Galaxy Book5 Pro 360
-     4. 750QHA - Galaxy Book5 360
-
-  Galaxy Book4:
-     5. 960XGL - Galaxy Book4 Ultra
-     6. 960XGK - Galaxy Book4 Pro
-     7. 940XGK - Galaxy Book4 Pro
-     [... more models ...]
-
-Enter model number (1-22): 5
-
-✓ Selected: 960XGL - Galaxy Book4 Ultra
-  Product: 960XGL
-  BIOS: P08ALX.400.250306.05
-```
-
-## Installation Guide
-
-### Step-by-Step
-
-1. **Run Installer as Administrator**
-
-   ```powershell
-   .\Install-GalaxyBookEnabler.ps1
-   ```
-
-2. **System Compatibility Check**
-   - Installer detects your Wi-Fi adapter
-   - Shows compatibility status for Quick Share
-
-3. **File Setup**
-   - Creates installation directory: `%USERPROFILE%\.galaxy-book-enabler`
-   - Detects legacy v1.x installation (if present)
-   - **Preserves custom BIOS values** from old QS.bat (Galaxy Book4 Ultra, GB4 Pro, etc.)
-   - Generates registry spoof script with preserved or default values
-   - Cleans up old installation files
-   - Saves configuration file
-
-4. **Startup Task Creation**
-   - Creates scheduled task "GalaxyBookEnabler"
-   - Runs automatically on system startup
-   - Uses SYSTEM privileges for registry access
-   - Creates scheduled task "GalaxyBookEnabler-MultiControlInit"
-   - Runs `Init-SamsungMultiControlOnLogin.ps1` at startup +5 minutes
-   - Adds a 1-minute grace period before Samsung service restarts
-
-5. **AI Select Configuration (Optional)**
-   - Create desktop shortcut
-   - Set up keyboard shortcut manually
-
-6. **System Support Engine (Optional/Advanced)**
-   - **Windows 11 only** - Experimental feature
-   - Downloads Samsung System Support Service CAB from Microsoft Update Catalog
-   - Extracts and patches binary executable
-   - Installs to `C:\GalaxyBook`
-   - Creates `GBeSupportService` Windows service (LocalSystem, Auto startup)
-   - Installs driver automatically via pnputil
-   - **Use with caution** - May trigger antivirus, requires advanced troubleshooting
-
-7. **Package Selection**
-   - Choose installation profile
-   - Review package list
-   - Confirm installation
-
-8. **Apply Registry Spoof**
-   - Immediate spoof application
-   - No reboot required for testing
-
-9. **Launch Galaxy Book Experience**
-   - Automatically opens after installation
-   - Explore available Samsung apps
-   - Access app catalog at any time
-
-10. **Reboot**
-
-- Restart your PC for full activation
-- Sign into Samsung Account
-- Configure Samsung apps
-
-## Troubleshooting
-
-### System Support Engine Issues
-
-- **Service not starting**: Check Event Viewer for errors
-- **Antivirus blocking**: Add `C:\GalaxyBook` to exclusions
-- **Driver not installing**: Manually install via Device Manager
-- **Samsung Settings not appearing**: Wait 5-10 minutes after reboot for background installation
-- **Service verification**: Run `Get-Service 'GBeSupportService'` in PowerShell
-- **Only for Windows 11**: Feature requires Windows 11 Build 22000 or higher
-
-### Quick Share Not Working
-
-- **Check Wi-Fi adapter type**: Quick Share requires **Intel Wi-Fi AX** (not AC)
-- **Check Bluetooth adapter**: Quick Share requires **Intel Bluetooth** radio
-- **AC card error**: If you see "A software or driver update is required", your Intel AC card is not supported
-- **AC9560 confirmed working**: Intel AC9560 has been tested and works with Quick Share
-- **Third-party Bluetooth**: USB Bluetooth dongles or non-Intel Bluetooth will cause failures
-- **Verify installation**: Check if app is properly installed
-- **Sign in**: Ensure you're signed into Samsung Account
-- **Alternative**: Use Google Nearby Share for non-Intel hardware
-
-### Apps Not Appearing
-
-- **Reboot required**: Some apps need a system restart
-- **Registry spoof**: Verify scheduled tasks are running
-- **Manual install**: Try installing apps individually from Microsoft Store
-
-### Multi Control Stops Working After Reboot
-
-- **Built-in recovery task**: Check Task Scheduler for `GalaxyBookEnabler-MultiControlInit`
-- **Expected timing**: Task starts at boot +5 minutes, script then waits 1 minute before restarting Samsung services
-- **Run manually**: `pwsh -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.galaxy-book-enabler\Init-SamsungMultiControlOnLogin.ps1"`
-- **Community context**: Added from user reports in [Discussion #76](https://github.com/Bananz0/GalaxyBookEnabler/discussions/76)
-- **Manual Task Scheduler fallback**:
-   - Trigger: At startup (Delay task for 5 minutes)
-   - Action: Program `pwsh.exe`
-   - Arguments: `-NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.galaxy-book-enabler\Init-SamsungMultiControlOnLogin.ps1" -GracePeriodSeconds 60`
-   - Security: Run with highest privileges as `SYSTEM`
-
-### Scheduled Task Not Running
-
-- **Check Task Scheduler**: Look for both `GalaxyBookEnabler` and `GalaxyBookEnabler-MultiControlInit`
-- **Permissions**: Tasks must run as SYSTEM with highest privileges
-- **Reinstall**: Run installer again to recreate task
-
-### Registry Spoof Not Persistent
-
-- **Verify startup task**: Check if task is enabled in Task Scheduler
-- **Run manually**: Execute `%USERPROFILE%\.galaxy-book-enabler\GalaxyBookSpoof.bat`
-- **Check logs**: Review Task Scheduler history
-
-### Installation Fails
-
-- **Admin rights**: Must run PowerShell as Administrator
-- **Winget issues**: Update winget: `winget upgrade --all`
-- **Network**: Verify internet connection for package downloads
-- **Antivirus**: Temporarily disable if blocking installation
-
-## FAQ
-
-**Q: Is this safe to use?**
-A: Yes, it only modifies volatile registry keys that reset on reboot. Scheduled tasks ensure the spoof and Multi Control service restart run automatically.
-
-**Q: Will this void my warranty?**
-A: This doesn't modify hardware or firmware. It only changes registry values.
-
-**Q: Can I use this on a real Samsung Galaxy Book?**
-A: There's no need - these features already work on genuine Galaxy Books.
-
-**Q: Why does Quick Share need Intel Wi-Fi?**
-A: Samsung designed Quick Share to work specifically with Intel's Wi-Fi Direct implementation. You need both **Intel Wi-Fi AX** (not AC) and **Intel Bluetooth** radios. Third-party Bluetooth adapters or Intel AC cards won't work.
-
-**Q: Can I uninstall specific packages later?**
-A: Yes, uninstall Samsung apps through Windows Settings → Apps like any other app.
-
-**Q: Do I need to keep the installer after installation?**
-A: No, but keep it if you want to update or uninstall later.
-
-**Q: Will this work on ARM Windows devices?**
-A: Not tested. The script is designed for x64 Windows systems.
-
-**Q: Can I customize the spoofed device model?**
-A: Advanced users can edit the batch file in the installation directory.
-
-## Updating
-
-### Check for Updates
-
-The installer detects if you have an older version installed and offers to update.
-
-### Manual Update
-
-```powershell
-# Download latest version
-irm https://raw.githubusercontent.com/Bananz0/GalaxyBookEnabler/main/Install-GalaxyBookEnabler.ps1 | iex
-```
-
-### What Gets Updated
-
-- Registry spoof script
-- Scheduled tasks configuration
-- Multi Control init script (`Init-SamsungMultiControlOnLogin.ps1`)
-- Package definitions
-- Helper functions
-
-## Uninstallation
-
-### Complete Removal
-
-```powershell
-.\Install-GalaxyBookEnabler.ps1 -Uninstall
-```
-
-### What Gets Removed
-
-- Scheduled tasks (`GalaxyBookEnabler`, `GalaxyBookEnabler-MultiControlInit`)
-- Installation directory (`%USERPROFILE%\.galaxy-book-enabler`)
-- Desktop shortcuts (if created)
-
-### What Stays
-
-- Installed Samsung apps (uninstall manually if desired)
-- Registry spoof (clears after reboot)
-
-### Manual Cleanup (if needed)
-
-```powershell
-# Remove scheduled tasks
-Unregister-ScheduledTask -TaskName "GalaxyBookEnabler" -Confirm:$false
-Unregister-ScheduledTask -TaskName "GalaxyBookEnabler-MultiControlInit" -Confirm:$false
-
-# Remove installation folder
-Remove-Item "$env:USERPROFILE\.galaxy-book-enabler" -Recurse -Force
-
-# Reboot to clear registry spoof
-Restart-Computer
-```
-
-## Privacy & Security
-
-- **No telemetry**: Script doesn't send any data
-- **Local only**: All operations are local to your PC
-- **Open source**: Full code is available for review
-- **No network access**: Script doesn't make outbound connections (except winget for packages)
-- **Reversible**: Complete uninstall available
-
-## Contributing
-
-Contributions are welcome! Please see [CONTRIBUTING.md](CONTRIBUTING.md) for our development process and CI requirements.
-
-1. Fork the repository
-2. Create a feature branch
-3. Test thoroughly
-4. Submit a pull request
-
-## Known Limitations
-
-- **Quick Share**: Requires Intel Wi-Fi AX adapter **AND** Intel Bluetooth radio (Some AC cards don't work)
-- **System Support Engine**: Windows 11 only, experimental, may cause instability
-- **Samsung Recovery**: Will never work (requires genuine Samsung hardware)
-- **Samsung Update**: Will never work (requires genuine Samsung hardware)
-- **Some features**: May require additional Samsung account setup
-- **Registry reset**: Spoof clears on reboot (handled by scheduled tasks)
-
-## Reporting Issues
-
-When reporting issues, please include:
-
-- **Installation log file** (automatically created at `%TEMP%\GalaxyBookEnabler_*.log`)
-  - The script creates a detailed diagnostic log during installation
-  - This log is created even when running via `irm | iex`
-  - Find it by pressing Win+R, typing `%TEMP%`, and looking for the newest `GalaxyBookEnabler_*.log` file
-  - Attach this file to your issue report for faster troubleshooting
-- Windows version (Settings → System → About)
-- PowerShell version (`$PSVersionTable.PSVersion`)
-- Wi-Fi adapter model (Device Manager → Network adapters)
-- Bluetooth adapter model (Device Manager → Bluetooth)
-- Error messages or screenshots
-- Steps to reproduce
-
-**Use our issue templates** when creating a new issue on GitHub:
-- 🐛 [Bug Report](.github/ISSUE_TEMPLATE/bug_report.yml) - For installation problems or features not working
-- 📊 [Hardware Compatibility Report](.github/ISSUE_TEMPLATE/hardware_compatibility.yml) - Share your hardware compatibility results
-- ✨ [Feature Request](.github/ISSUE_TEMPLATE/feature_request.yml) - Suggest new features
-
-## License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## Credits
-
-- Original script by [@obrobrio2000](https://github.com/obrobrio2000)
-- Enhanced and maintained by [@Bananz0](https://github.com/Bananz0)
-- Inspired by [eGPUae](https://github.com/bananz0/eGPUae) architecture
-
-## Supporters
-
-A huge thanks to the following people for supporting this project ❤️ :
-
-- **@Hydro3ia**
-- **@systemsrethinking**
-- **@intini**
-
-### Bluetooth Device Removal
-
-- [@m-a-x-s-e-e-l-i-g](https://github.com/m-a-x-s-e-e-l-i-g) - [powerBTremover (fork)](https://github.com/m-a-x-s-e-e-l-i-g/powerBTremover)
-- [@RS-DU34](https://github.com/RS-DU34) - [powerBTremover (original)](https://github.com/RS-DU34/powerBTremover)
-
-## Disclaimer
-
-**IMPORTANT**:
-
-- This tool is for educational and personal use only
-- Not affiliated with or endorsed by Samsung Electronics
-- Use at your own risk
-- Author is not responsible for any issues or damages
-- Samsung may update their apps to detect or block this method
-- Features may break with future Samsung app updates
-
-## Legal Notice
-
-### Interoperability Notice (EU)
-
-This software is developed for the purpose of achieving interoperability between Samsung software services and third-party hardware platforms (non-Samsung PCs), in accordance with the rights granted under the EU Computer Programs Directive (2009/24/EC). It allows users to exercise their right to use legally obtained software on the hardware of their choice by resolving arbitrary compatibility checks.
-
-## Links
-
-- [GitHub Repository](https://github.com/Bananz0/GalaxyBookEnabler)
-- [Issues & Bug Reports](https://github.com/Bananz0/GalaxyBookEnabler/issues)
-- [Changelog](CHANGELOG.md)
-- [Google Nearby Share Alternative](https://www.android.com/better-together/nearby-share-app/)
-
----
-
-> Made with ❤️ for the Samsung ecosystem enthusiasts
+* Works with any Wi-Fi adapter
+* Similar file-sharing functionality
+* Cross-platform support (Windows, Android, ChromeOS)
+* Download: [Google Nearby Share](https://www.android.com/better-together/nearby-share-app/)
+
+[1]: https://raw.githubusercontent.com/Chiragsd13/GalaxyBookEnabler/main/README.md "raw.githubusercontent.com"


### PR DESCRIPTION
## Summary

This PR bumps the script to **v3.2.0** and adds several improvements:

### New SMBIOS Profiles
- **Galaxy Book6 Ultra** (`960XKB`) — Intel Panther Lake, AMI BIOS `P01AMC.100.260120.01`
- **Galaxy Book6 Pro** (`960XKA`) — Intel Panther Lake, AMI BIOS `P01AMB.100.260115.01`

### New Platform Detection Functions
- `Get-CPUPlatform` — Detects Intel / AMD / ARM
- `Get-WifiPlatform` — Detects Wi-Fi vendor; flags Quick Share compatibility
- `Get-BluetoothPlatform` — Detects Bluetooth vendor

### Hardware Compatibility Report
- `Show-HardwareCompatibility` — Pre-install compatibility matrix

### Improved Model Selection Menu
- Grouped by series: Book6 / Book5 / Book4 / Book3 / Legacy

### Docs
- Updated .DESCRIPTION with all 23 profiles and AMD/ARM guidance
- Updated CHANGELOG.md with v3.2.0 entry

---
*Patch Author: Chirag Sood <chiragsd13@gmail.com>*